### PR TITLE
Use correct error codes for cardnumber validation

### DIFF
--- a/worldpay-js/worldpay-cse.js
+++ b/worldpay-js/worldpay-cse.js
@@ -338,9 +338,9 @@ function validateCardNumber(cardNumber) {
 	if(!isEmpty(cardNumber)) {
 		if(evaluateRegex(cardNumber, "^[0-9]{12,20}$")) {
 			if (doLuhnCheck(cardNumber)) { return 0;
-			} else { return 103; }
+			} else { return 102; }
 		}
-		else { return 102; }
+		else { return 103; }
 	} else { return 101;}
 }
 function doLuhnCheck(value) {


### PR DESCRIPTION
According to the guide - http://support.worldpay.com/support/kb/gg/client-side-encryption/Content/F%20-%20Troubleshooter/Troubleshooter.htm

102 should signify a Luhn failure and 103 should test whether the characters are number and between 12 and 20 chars in length