### PR TITLE
Add validateFields to public interface, so that clients can run realt…

### DIFF
--- a/worldpay-js/worldpay-cse.js
+++ b/worldpay-js/worldpay-cse.js
@@ -59,6 +59,15 @@ worldpayCse.encrypt = encrypt;
  */
 worldpayCse.setPublicKey = setPublicKey;
 
+/**
+ * Validate card details
+ *
+ * @function
+ * @param {CardData} cardData - An object containing information about the card details to validate.
+ * @returns [errorHandler] - An array of error numbers
+ */
+worldpayCse.validateFields = validateFields;
+
 if (typeof global.define === "function" && global.define.amd) {
 	global.define(function() {
 		return worldpayCse;


### PR DESCRIPTION
I've added validateFields to the public interface so that we can run the validation before we call Encrypt. 

This change lets us replicate Worldpay HPP where the customer can see errors as they are typing.

At the moment, we call "Encrypt" to run the validation (validateFields is the first thing Encrypt calls). But this means we are running encryption when we don't need to. We only want to encrypt when the customer submits their payments details.