### PR TITLE
Increase max card-holder length to 34

### DIFF
--- a/worldpay-js/worldpay-cse.js
+++ b/worldpay-js/worldpay-cse.js
@@ -333,7 +333,7 @@ function isFutureDate(expiryMonth, expiryYear) {
 
 function validateCardHolderName(cardHolderName) {
 	if(!isEmpty(cardHolderName)) {
-		if(evaluateRegex(cardHolderName, "^.{1,30}$")) {
+		if(evaluateRegex(cardHolderName, "^.{1,34}$")) {
 			return 0;
 		} else { return 402;}
 	} else { return 401;}


### PR DESCRIPTION
Increase max card-holder length to 34 to support the largest magic test value: `3DS_V2_FRICTIONLESS_NOT_IDENTIFIED`